### PR TITLE
[Refactor] seperate the load_data function into sub-fuctions

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -17,7 +17,7 @@ from rdkit.Chem.Scaffolds import MurckoScaffold
 torch.set_num_threads(5)
 RDLogger.DisableLog('rdApp.*') 
 from loss import discriminator_loss, generator_loss, discriminator2_loss, generator2_loss
-from training_data import load_data
+from training_data import generate_z_values, load_molecules
 import random
 from tqdm import tqdm
 
@@ -567,19 +567,42 @@ class Trainer(object):
 
                 # Preprocess both dataset 
                 
-                bulk_data = load_data(data,
-                                     drugs,
-                                     self.batch_size, 
-                                     self.device,
-                                     self.b_dim,
-                                     self.m_dim,
-                                     self.drugs_b_dim,
-                                     self.drugs_m_dim,
-                                     self.z_dim,
-                                     self.vertexes)   
+                # bulk_data = load_data(data,
+                #                      drugs,
+                #                      self.batch_size, 
+                #                      self.device,
+                #                      self.b_dim,
+                #                      self.m_dim,
+                #                      self.drugs_b_dim,
+                #                      self.drugs_m_dim,
+                #                      self.z_dim,
+                #                      self.vertexes)   
                 
-                drug_graphs, real_graphs, a_tensor, x_tensor, drugs_a_tensor, drugs_x_tensor, z, z_edge, z_node = bulk_data
+                # drug_graphs, real_graphs, a_tensor, x_tensor, drugs_a_tensor, drugs_x_tensor, z, z_edge, z_node = bulk_data
                 
+                z, z_edge, z_node = generate_z_values(
+                    batch_size=self.batch_size,
+                    z_dim=self.z_dim,
+                    vertexes=self.vertexes,
+                    device=self.device,
+                )
+
+                real_graphs, a_tensor, x_tensor = load_molecules(
+                    data=data, 
+                    batch_size=self.batch_size,
+                    device=self.device,
+                    b_dim=self.b_dim,
+                    m_dim=self.m_dim,
+                )
+
+                drug_graphs, drugs_a_tensor, drugs_x_tensor = load_molecules(
+                    data=drugs, 
+                    batch_size=self.batch_size,
+                    device=self.device,
+                    b_dim=self.drugs_b_dim,
+                    m_dim=self.drugs_m_dim,
+                )
+
                 if self.submodel == "CrossLoss":
                     GAN1_input_e = a_tensor
                     GAN1_input_x = x_tensor
@@ -797,19 +820,42 @@ class Trainer(object):
 
                 # Preprocess both dataset 
                 
-                bulk_data = load_data(data,
-                                     drugs,
-                                     self.inf_batch_size, 
-                                     self.device,
-                                     self.b_dim,
-                                     self.m_dim,
-                                     self.drugs_b_dim,
-                                     self.drugs_m_dim,
-                                     self.z_dim,
-                                     self.vertexes)   
+                # bulk_data = load_data(data,
+                #                      drugs,
+                #                      self.inf_batch_size, 
+                #                      self.device,
+                #                      self.b_dim,
+                #                      self.m_dim,
+                #                      self.drugs_b_dim,
+                #                      self.drugs_m_dim,
+                #                      self.z_dim,
+                #                      self.vertexes)   
                 
-                drug_graphs, real_graphs, a_tensor, x_tensor, drugs_a_tensor, drugs_x_tensor, z, z_edge, z_node = bulk_data
+                # drug_graphs, real_graphs, a_tensor, x_tensor, drugs_a_tensor, drugs_x_tensor, z, z_edge, z_node = bulk_data
                 
+                z, z_edge, z_node = generate_z_values(
+                    batch_size=self.batch_size,
+                    z_dim=self.z_dim,
+                    vertexes=self.vertexes,
+                    device=self.device,
+                )
+
+                real_graphs, a_tensor, x_tensor = load_molecules(
+                    data=data, 
+                    batch_size=self.batch_size,
+                    device=self.device,
+                    b_dim=self.b_dim,
+                    m_dim=self.m_dim,
+                )
+
+                drug_graphs, drugs_a_tensor, drugs_x_tensor = load_molecules(
+                    data=drugs, 
+                    batch_size=self.batch_size,
+                    device=self.device,
+                    b_dim=self.drugs_b_dim,
+                    m_dim=self.drugs_m_dim,
+                )
+
                 if self.submodel == "CrossLoss":
                     GAN1_input_e = a_tensor
                     GAN1_input_x = x_tensor

--- a/training_data.py
+++ b/training_data.py
@@ -1,50 +1,93 @@
 import torch
 import torch_geometric.utils as geoutils
-from utils import *
+from utils import label2onehot
 
-def load_data(data, drugs, batch_size, device, b_dim, m_dim, drugs_b_dim, drugs_m_dim,z_dim,vertexes):
+def generate_z_values(batch_size=32, z_dim=32, vertexes=32, b_dim=32, m_dim=32, device=None):
+    z = torch.normal(mean=0, std=1, size=(batch_size, z_dim), device=device) # (batch,max_len)
+    z_edge = torch.normal(mean=0, std=1, size=(batch_size, vertexes, vertexes, b_dim), device=device) # (batch,max_len,max_len)
+    z_node = torch.normal(mean=0, std=1, size=(batch_size, vertexes, m_dim), device=device) # (batch,max_len)
 
-    z = sample_z(batch_size, z_dim)                                                   # (batch,max_len)          
+    z = z.float().requires_grad_(True)
+    z_edge = z_edge.float().requires_grad_(True)                                      # Edge noise.(batch,max_len,max_len)
+    z_node = z_node.float().requires_grad_(True)                                      # Node noise.(batch,max_len)
+    return z, z_edge, z_node
 
-    z = torch.from_numpy(z).to(device).float().requires_grad_(True)                
+# def load_data(
+#     data=None,
+#     drugs=None,
+#     batch_size=32,
+#     device=None,
+#     b_dim=32,
+#     m_dim=32,
+#     drugs_b_dim=32,
+#     drugs_m_dim=32,
+#     # z_dim=32,
+#     # vertexes=32
+# ):
+    
+#     data = data.to(device)
+#     drugs = drugs.to(device)
+    
+#     a = geoutils.to_dense_adj(
+#         edge_index = data.edge_index,
+#         batch=data.batch,
+#         edge_attr=data.edge_attr,
+#         max_num_nodes=int(data.batch.shape[0]/batch_size)
+#     )
+
+#     x_tensor = data.x.view(batch_size,int(data.batch.shape[0]/batch_size),-1)
+
+#     a_tensor = label2onehot(a, b_dim, device)
+#     #x_tensor = label2onehot(x, m_dim)
+#     # x_tensor = x
+
+#     # a_tensor = a_tensor #+ torch.randn([a_tensor.size(0), a_tensor.size(1), a_tensor.size(2),1], device=a_tensor.device) * noise_strength_0
+#     # x_tensor = x_tensor #+ torch.randn([x_tensor.size(0), x_tensor.size(1),1], device=x_tensor.device) * noise_strength_1
+
+#     drugs_a = geoutils.to_dense_adj(
+#         edge_index=drugs.edge_index,
+#         batch=drugs.batch,
+#         edge_attr=drugs.edge_attr,
+#         max_num_nodes=int(drugs.batch.shape[0]/batch_size)
+#     )
+
+#     drugs_x = drugs.x.view(batch_size,int(drugs.batch.shape[0]/batch_size),-1)
+
+#     drugs_a = drugs_a.to(device).long() 
+#     drugs_x = drugs_x.to(device)
+#     drugs_a_tensor = label2onehot(drugs_a, drugs_b_dim,device).float()
+#     drugs_x_tensor = drugs_x
+
+#     # drugs_a_tensor = drugs_a_tensor #+ torch.randn([drugs_a_tensor.size(0), drugs_a_tensor.size(1), drugs_a_tensor.size(2),1], device=drugs_a_tensor.device) * noise_strength_2
+#     # drugs_x_tensor = drugs_x_tensor #+ torch.randn([drugs_x_tensor.size(0), drugs_x_tensor.size(1),1], device=drugs_x_tensor.device) * noise_strength_3
+#     #prot_n = akt1_human_annot[None,:].to(device).float()        
+#     #prot_e = akt1_human_adj[None,None,:].view(1,546,546,1).to(device).float()
+
+
+#     a_tensor_vec = a_tensor.reshape(batch_size,-1)
+#     x_tensor_vec = x_tensor.reshape(batch_size,-1)               
+#     real_graphs = torch.concat((x_tensor_vec,a_tensor_vec),dim=-1)                      
+
+#     a_drug_vec = drugs_a_tensor.reshape(batch_size,-1)
+#     x_drug_vec = drugs_x_tensor.reshape(batch_size,-1)               
+#     drug_graphs = torch.concat((x_drug_vec,a_drug_vec),dim=-1)  
+    
+#     return drug_graphs, real_graphs, a_tensor, x_tensor, drugs_a_tensor, drugs_x_tensor
+
+
+def load_molecules(batch=None, b_dim=32, m_dim=32, device=None, batch_size=32):
     data = data.to(device)
-    drugs = drugs.to(device)                                               
-    z_e = sample_z_edge(batch_size,vertexes,b_dim)                                                   # (batch,max_len,max_len)    
-    z_n = sample_z_node(batch_size,vertexes,m_dim)                                                   # (batch,max_len)          
-    z_edge = torch.from_numpy(z_e).to(device).float().requires_grad_(True)                                      # Edge noise.(batch,max_len,max_len)
-    z_node = torch.from_numpy(z_n).to(device).float().requires_grad_(True)                                      # Node noise.(batch,max_len)       
-    a = geoutils.to_dense_adj(edge_index = data.edge_index,batch=data.batch,edge_attr=data.edge_attr, max_num_nodes=int(data.batch.shape[0]/batch_size)) 
-    x = data.x.view(batch_size,int(data.batch.shape[0]/batch_size),-1)
-
+    a = geoutils.to_dense_adj(
+        edge_index = data.edge_index,
+        batch=data.batch,
+        edge_attr=data.edge_attr,
+        max_num_nodes=int(data.batch.shape[0]/batch_size)
+    )
+    x_tensor = data.x.view(batch_size,int(data.batch.shape[0]/batch_size),-1)
     a_tensor = label2onehot(a, b_dim, device)
-    #x_tensor = label2onehot(x, m_dim)
-    x_tensor = x
-
-    a_tensor = a_tensor #+ torch.randn([a_tensor.size(0), a_tensor.size(1), a_tensor.size(2),1], device=a_tensor.device) * noise_strength_0
-    x_tensor = x_tensor #+ torch.randn([x_tensor.size(0), x_tensor.size(1),1], device=x_tensor.device) * noise_strength_1
-
-    drugs_a = geoutils.to_dense_adj(edge_index = drugs.edge_index,batch=drugs.batch,edge_attr=drugs.edge_attr, max_num_nodes=int(drugs.batch.shape[0]/batch_size))
-
-    drugs_x = drugs.x.view(batch_size,int(drugs.batch.shape[0]/batch_size),-1)
-
-    drugs_a = drugs_a.to(device).long() 
-    drugs_x = drugs_x.to(device)
-    drugs_a_tensor = label2onehot(drugs_a, drugs_b_dim,device).float()
-    drugs_x_tensor = drugs_x
-
-    drugs_a_tensor = drugs_a_tensor #+ torch.randn([drugs_a_tensor.size(0), drugs_a_tensor.size(1), drugs_a_tensor.size(2),1], device=drugs_a_tensor.device) * noise_strength_2
-    drugs_x_tensor = drugs_x_tensor #+ torch.randn([drugs_x_tensor.size(0), drugs_x_tensor.size(1),1], device=drugs_x_tensor.device) * noise_strength_3
-    #prot_n = akt1_human_annot[None,:].to(device).float()        
-    #prot_e = akt1_human_adj[None,None,:].view(1,546,546,1).to(device).float()
-
-            
 
     a_tensor_vec = a_tensor.reshape(batch_size,-1)
-    x_tensor_vec = x_tensor.reshape(batch_size,-1)               
-    real_graphs = torch.concat((x_tensor_vec,a_tensor_vec),dim=-1)                      
+    x_tensor_vec = x_tensor.reshape(batch_size,-1)
+    real_graphs = torch.concat((x_tensor_vec,a_tensor_vec),dim=-1)
 
-    a_drug_vec = drugs_a_tensor.reshape(batch_size,-1)
-    x_drug_vec = drugs_x_tensor.reshape(batch_size,-1)               
-    drug_graphs = torch.concat((x_drug_vec,a_drug_vec),dim=-1)  
-    
-    return drug_graphs, real_graphs, a_tensor, x_tensor, drugs_a_tensor, drugs_x_tensor, z, z_edge, z_node
+    return real_graphs, a_tensor, x_tensor

--- a/utils.py
+++ b/utils.py
@@ -140,27 +140,6 @@ def label2onehot(labels, dim, device):
     return out.float()
 
 
-def sample_z_node(batch_size, vertexes, nodes):
-    
-    ''' Random noise for nodes logits. '''
-    
-    return np.random.normal(0,1, size=(batch_size,vertexes, nodes))  #  128, 9, 5
-
-
-def sample_z_edge(batch_size, vertexes, edges):
-    
-    ''' Random noise for edges logits. '''
-    
-    return np.random.normal(0,1, size=(batch_size, vertexes, vertexes, edges)) # 128, 9, 9, 5
-
-
-def sample_z( batch_size, z_dim):
-    
-    ''' Random noise. '''
-    
-    return np.random.normal(0,1, size=(batch_size,z_dim))  #  128, 9, 5       
-
-
 def mol_sample(sample_directory, model_name, mol, edges, nodes, idx, i):
     sample_path = os.path.join(sample_directory,"{}-{}_{}-epoch_iteration".format(model_name,idx+1, i+1))
     


### PR DESCRIPTION
This would allow us to separate preprocessing steps, and increase the readability and documentation. As a next step forward we can directly add these into the dataset, and cache the results. 

I generated the Z values from directly pytorch functions. And It seems that the drugs and molecules are passing through the same steps.

If this PR looks ok, i can remove the commented lines