### PR TITLE
Refactor Argument Name in load_molecules Function for removing error from training code

### DIFF
--- a/training_data.py
+++ b/training_data.py
@@ -75,7 +75,7 @@ def generate_z_values(batch_size=32, z_dim=32, vertexes=32, b_dim=32, m_dim=32, 
 #     return drug_graphs, real_graphs, a_tensor, x_tensor, drugs_a_tensor, drugs_x_tensor
 
 
-def load_molecules(batch=None, b_dim=32, m_dim=32, device=None, batch_size=32):
+def load_molecules(data=None, b_dim=32, m_dim=32, device=None, batch_size=32):
     data = data.to(device)
     a = geoutils.to_dense_adj(
         edge_index = data.edge_index,


### PR DESCRIPTION
## Description:
This pull request addresses a minor but crucial update in the training_data.py file. The load_molecules function previously took an argument named batch, which could be misleading and did not accurately describe the expected input. I have refactored the argument name to data, which aligns with the typical naming conventions used within the codebase and accurately represents the input as the data to be processed, which solves the error due wrong argument name.

